### PR TITLE
update windows CI to glib 2.74

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,11 +10,11 @@ jobs:
 
   gvsbuild:
     name: build GTK binaries with gvsbuild
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     env:
       # git revision of gvsbuild we use for to build GLib and the other dependencies
-      gvsbuildref: 0121d5bee2e62f1fd6e89a9edab32f9f5765e04a
+      gvsbuildref: 078140d0b7dcfd6147b3063114fb38365b7ad5a1
 
       # bump this number if you want to force a rebuild of gvsbuild with the same revision
       gvsbuildupdate: 1
@@ -45,17 +45,25 @@ jobs:
       # Temporarily move the preinstalled git, it causes errors related to cygwin.
       - name: (GTK binaries) move git binary
         if: steps.cache.outputs.cache-hit != 'true'
-        run: move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
+        run: |
+          move "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
+          move "C:\Program Files\Git\bin" "C:\Program Files\Git\notbin"
         shell: cmd
+
+      - name: (GTK binaries) install gvsbuild
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: gvsbuild
+        run: python -m pip install .
 
       - name: (GTK binaries) run gvsbuild
         if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: gvsbuild
-        run: python .\build.py build -p=x64 --vs-ver=16 --msys-dir=C:\msys64 glib cairo pango gdk-pixbuf graphene
+        run: gvsbuild build --platform=x64 --vs-ver=17 --msys-dir=C:\msys64 gtk3 graphene
 
       - name: (GTK binaries) restore git binary
         if: steps.cache.outputs.cache-hit != 'true'
-        run: move "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
+        run: |
+          move "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
+          move "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
         shell: cmd
 
       - name: (GTK binaries) output cache key
@@ -64,7 +72,7 @@ jobs:
 
   build:
     name: build gtk-rs on Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: gvsbuild
 
     strategy:
@@ -72,8 +80,8 @@ jobs:
         conf:
           - { name: "cairo", test: true, args: "--features png,pdf,svg,ps,use_glib,v1_16,freetype,script,win32-surface" }
           - { name: "gdk-pixbuf", test: true, args: "--features v2_42" }
-          - { name: "gio", test: true, args: "--features v2_72" }
-          - { name: "glib", test: true, args: "--features v2_72" }
+          - { name: "gio", test: true, args: "--features v2_74" }
+          - { name: "glib", test: true, args: "--features v2_74" }
           - { name: "glib-build-tools", test: false, args: "" }
           - { name: "graphene", test: false, args: "" }
           - { name: "pango", test: true, args: "--features v1_50" }


### PR DESCRIPTION
Also update the windows VM so we can get the latest version of python and gvsbuild, and update gvsbuild command as it now works like a real python package.